### PR TITLE
Fix for "Using --linebreak LF does not produce a "\n" but is taken literally in to the file"

### DIFF
--- a/src/autoloadbuildercli.php
+++ b/src/autoloadbuildercli.php
@@ -305,7 +305,7 @@ namespace TheSeer\Tools {
          $linebreak = $input->getOption('linebreak');
          if ($linebreak->value !== false) {
             $lbr = array('LF' => "\n", 'CR' => "\r", 'CRLF' => "\r\n" );
-            if (in_array($linebreak->value, $lbr)) {
+            if (isset($lbr[$linebreak->value])) {
                $ab->setLineBreak($lbr[$linebreak->value]);
             } else {
                $ab->setLineBreak($linebreak->value);
@@ -423,3 +423,4 @@ EOF;
       }
    }
 }
+


### PR DESCRIPTION
Hi Arne,

the "in_array" check just seems off here and the "literal" parameters get written into the file.

I didn't see a test for the cli class so i didn't write any tests.

Regards,
Volker
