### PR TITLE
Changed the autoload-function name to be reproducible

### DIFF
--- a/src/autoloadbuilder.php
+++ b/src/autoloadbuilder.php
@@ -285,7 +285,7 @@ namespace TheSeer\Autoload {
             '___CREATED___'   => date( $this->dateformat, $this->timestamp ? $this->timestamp : time()),
             '___CLASSLIST___' => join( ',' . $this->linebreak . $this->indent, $entries),
             '___BASEDIR___'   => $baseDir,
-            '___AUTOLOAD___'  => uniqid('autoload')
+            '___AUTOLOAD___'  => 'autoload' . md5(serialize($entries))
             ));
             return str_replace(array_keys($replace), array_values($replace), $this->template);
         }

--- a/tests/autoloadbuilder.test.php
+++ b/tests/autoloadbuilder.test.php
@@ -242,10 +242,27 @@ namespace TheSeer\Autoload\Tests {
          * @depends testSettingTemplateCode
          * @covers \TheSeer\Autoload\AutoloadBuilder::render
          */
+        public function testGetUniqueReproducibleValueForAutoloadName() {
+            $ab = new \TheSeer\Autoload\AutoloadBuilder($this->classlist);
+            $ab->setTemplateCode('___AUTOLOAD___');
+            $first = $ab->render();
+            $this->assertEquals($first, $ab->render());
+        }
+
+        /**
+         *
+         * @depends testSettingTemplateCode
+         * @covers \TheSeer\Autoload\AutoloadBuilder::render
+         */
         public function testGetUniqueValueForAutoloadName() {
             $ab = new \TheSeer\Autoload\AutoloadBuilder($this->classlist);
             $ab->setTemplateCode('___AUTOLOAD___');
             $first = $ab->render();
+
+            $aSecond = $this->classlist;
+            array_pop($aSecond);
+            $ab = new \TheSeer\Autoload\AutoloadBuilder($aSecond);
+            $ab->setTemplateCode('___AUTOLOAD___');
             $this->assertNotEquals($first, $ab->render());
         }
 


### PR DESCRIPTION
Currently Autoload will change the autoload-file, even if there are actually no changes in the class-list. When using Autoload not only within the deployment or completely manually this might change the autoload-file far too often.

The patch will ensure that the autoload-function-name changes only when the classlist is changed. This might be an cli-option, too.
