### PR TITLE
Fixed namespace issue with tests

### DIFF
--- a/src/classfinder.php
+++ b/src/classfinder.php
@@ -236,7 +236,7 @@ namespace TheSeer\Tools {
        */
       public function parseMulti(\Iterator $sources) {
          $count = 0;
-         $worker  = new PHPFilterIterator($sources);
+         $worker  = new \TheSeer\DirectoryScanner\PHPFilterIterator($sources);
          foreach($worker as $file) {
             $count += $this->parseFile($file->getPathname());
          }


### PR DESCRIPTION
Running the tests on linux resulted in: 

> Fatal error: Class 'TheSeer\Tools\PHPFilterIterator' not found in /home/edo/Desktop/PHP/Autoload/src/classfinder.php on line 239

Not sure if that code just doesn't executed or why it works for you (Maybe different directoryScanner version?)

I thought I'll just submit the pull. Just in case
