### PR TITLE
define date.timezone to avoid warning (in buildystem)

### DIFF
--- a/phpab.php
+++ b/phpab.php
@@ -44,6 +44,10 @@
 
 define('PHPAB_VERSION', '%development%');
 
+if (!ini_get('date.timezone')) {
+     ini_set('date.timezone', 'UTC');
+}
+
 require 'TheSeer/DirectoryScanner/autoload.php';
 require 'ezc/Base/base.php';
 


### PR DESCRIPTION
date.timezone have to be defined by admin after PHP install.

So in Fedora bulid system (and perhaps other), it is not defined, so every package have to pass it as phpunit command

```
phd -d date.timezone=UTC /usr/bin/phpab ...
```

I think it could have some value (at least for us) to avoid this, and of course, value defined in configuration or command options still have higher priority.
