### PR TITLE
Fix warning and generated path when file above basedir

### DIFF
--- a/src/AutoloadRenderer.php
+++ b/src/AutoloadRenderer.php
@@ -233,7 +233,6 @@ namespace TheSeer\Autoload {
             if ($pos<count($basedir)) {
                 $rel = str_repeat('../', count($basedir)-$pos) . $rel;
             }
-            var_dump($fname,  '/' . (!empty($rel) ? $rel : '') . basename($fname));
             return '/' . $rel . basename($fname);
         }
 


### PR DESCRIPTION
Trying to generate autoloader for phpdocumentor/reflection-docblock (=> Undefined offset)

```
 $ phpab \
       --basedir src/phpDocumentor/Reflection/DocBlock \
       --output src/phpDocumentor/Reflection/DocBlock/autoload.php \
       src/phpDocumentor/Reflection
 phpab 1.16.2 - Copyright (C) 2009 - 2014 by Arne Blankerts
 Scanning directory src/phpDocumentor/Reflection
 Notice: Undefined offset: 11 in /usr/share/php/TheSeer/Autoload/AutoloadRenderer.php on line 220
 Autoload file src/phpDocumentor/Reflection/DocBlock/autoload.php generated.
```

And in generated autoloader (double /)

```
            'phpdocumentor\\reflection\\docblock' => '/..//DocBlock.php',
```

This should fix both
