### PR TITLE
try to allow files from composer.json, autoload.classmap

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -74,11 +74,16 @@ namespace TheSeer\Autoload {
             }
             $collector = $this->factory->getCollector();
             foreach ($this->config->getDirectories() as $directory) {
-                $this->logger->log('Scanning directory ' . $directory . "\n");
-                $scanner = $this->factory->getScanner()->getIterator($directory);
-                $collector->processDirectory($scanner);
-                // this unset is needed to "fix" a segfault on shutdown in some PHP Versions
-                unset($scanner);
+                if (is_dir($directory)) {
+                    $this->logger->log('Scanning directory ' . $directory . "\n");
+                    $scanner = $this->factory->getScanner()->getIterator($directory);
+                    $collector->processDirectory($scanner);
+                    // this unset is needed to "fix" a segfault on shutdown in some PHP Versions
+                    unset($scanner);
+                } else {
+                    $this->logger->log('Scanning file ' . $directory . "\n");
+                    $collector->processFile(new \SplFileInfo($directory));
+                }
             }
             return $collector->getResult();
         }

--- a/src/Collector.php
+++ b/src/Collector.php
@@ -44,6 +44,11 @@ namespace TheSeer\Autoload {
         public function processDirectory(\Iterator $sources) {
             $worker = $this->paranoidMode ? new PHPFilterIterator($sources) : $sources;
             foreach($worker as $file) {
+                $this->processFile($file);
+            }
+        }
+
+        public function processFile(\SplFileInfo $file) {
                 try {
                     $parseResult = $this->parser->parse(new SourceFile($file->getRealpath()));
                     if ($parseResult->hasRedeclarations() && !$this->tolerantMode) {
@@ -72,7 +77,6 @@ namespace TheSeer\Autoload {
                         CollectorException::RedeclarationFound
                     );
                 }
-            }
         }
     }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -84,7 +84,7 @@ namespace TheSeer\Autoload {
                 return realpath($this->baseDirectory);
             }
             $tmp = $this->getDirectories();
-            return realpath($tmp[0]);
+            return realpath(is_dir($tmp[0]) ? $tmp[0] : (dirname($tmp[0])) ?: '.');
         }
 
         public function setCompatMode($compatMode) {

--- a/src/Config.php
+++ b/src/Config.php
@@ -84,7 +84,7 @@ namespace TheSeer\Autoload {
                 return realpath($this->baseDirectory);
             }
             $tmp = $this->getDirectories();
-            return realpath(is_dir($tmp[0]) ? $tmp[0] : (dirname($tmp[0])) ?: '.');
+            return realpath(is_dir($tmp[0]) ? $tmp[0] : (dirname($tmp[0]) ?: '.'));
         }
 
         public function setCompatMode($compatMode) {


### PR DESCRIPTION
Probably not the clean way to do it... but...

From Smarty sources, https://github.com/smarty-php/smarty

    $ phpab --output libs/autoload.php  composer.json 
    phpab 1.17.0 - Copyright (C) 2009 - 2015 by Arne Blankerts
    
    Scanning directory /tmp/smarty-4537d8aae6c4a26f5439bc3a05d3437d25c2c4d2/libs/Smarty.class.php
    
    Error while processing request:
     - RecursiveDirectoryIterator::__construct(/tmp/smarty-4537d8aae6c4a26f5439bc3a05d3437d25c2c4d2/libs/Smarty.class.php): failed to open dir: N'est pas un dossier

With this patch

    $ php /work/GIT/Autoload/phpab.php --output libs/autoload.php composer.json 
    phpab 1.17.0-1-g5d5e5b4-dirty - Copyright (C) 2009 - 2015 by Arne Blankerts
    
    Scanning file /tmp/smarty-4537d8aae6c4a26f5439bc3a05d3437d25c2c4d2/libs/Smarty.class.php
    Scanning file /tmp/smarty-4537d8aae6c4a26f5439bc3a05d3437d25c2c4d2/libs/SmartyBC.class.php
    Scanning directory /tmp/smarty-4537d8aae6c4a26f5439bc3a05d3437d25c2c4d2/libs/sysplugins
    
    Autoload file libs/autoload.php generated.
