### PR TITLE
also accept files in CLI arguments

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -334,14 +334,13 @@ namespace TheSeer\Autoload {
         public function getDirectories() {
             $list = array();
             foreach($this->directories as $dir) {
-                foreach(glob($dir) as $match) {
-                    if (is_dir($match)) {
-                        $list[] = $match;
+                if (is_file($dir) && basename($dir) == 'composer.json') {
+                    foreach(new ComposerIterator(new \SplFileInfo($dir)) as $d) {
+                        $list[] = $d;
                     }
-                    if (is_file($dir) && basename($dir) == 'composer.json') {
-                        foreach(new ComposerIterator(new \SplFileInfo($dir)) as $d) {
-                            $list[] = $d;
-                        }
+                } else {
+                    foreach(glob($dir) as $match) {
+                        $list[] = $match;
                     }
                 }
             }


### PR DESCRIPTION
With PR #56 files are only allowed from composer.json.

But as in rev e97c1d4 you also add "file" in help output, I think it need to be fixed ;)
