### PR TITLE
Fix syntax error in PHP 5.2-compatible autoloader

### DIFF
--- a/src/templates/ci/php52.php.tpl
+++ b/src/templates/ci/php52.php.tpl
@@ -12,9 +12,7 @@ function ___AUTOLOAD___($class) {
     $cn = strtolower($class);
     if (isset($classes[$cn])) {
         require ___BASEDIR___$classes[$cn];
-    },
-    ___EXCEPTION___,
-    ___PREPEND___
+    }
 }
 spl_autoload_register('___AUTOLOAD___');
 // @codeCoverageIgnoreEnd


### PR DESCRIPTION
Fixes #61