### PR TITLE
fix PathComparator when 0 in path

### DIFF
--- a/src/PathComparator.php
+++ b/src/PathComparator.php
@@ -27,7 +27,7 @@ namespace TheSeer\Autoload {
             foreach($this->directories as $dir) {
                 $result = substr($dir, 0, $this->commonPrefix($result, $dir));
             }
-            return rtrim($result,'/');
+            return rtrim($result, '/');
         }
 
 

--- a/src/PathComparator.php
+++ b/src/PathComparator.php
@@ -33,7 +33,7 @@ namespace TheSeer\Autoload {
 
         private function commonPrefix( $s1, $s2, $i=0 ) {
             return (
-                !empty($s1[$i]) && !empty($s2[$i]) && $s1[$i] == $s2[$i]
+                $i<strlen($s1) && $i<strlen($s2) && $s1[$i] == $s2[$i]
             ) ? $this->commonPrefix( $s1, $s2, ++$i ) : $i;
         }
     }

--- a/tests/PathComparator.test.php
+++ b/tests/PathComparator.test.php
@@ -27,6 +27,9 @@ namespace TheSeer\Autoload\Tests {
                 ],
                 'partns' => [
                     array(__DIR__ . '/../src', __DIR__ . '/../vendor/theseer'), dirname(__DIR__)
+                ],
+                'with0' => [
+                    [$a=__DIR__.'/_data/parser/trait0.php'], $a
                 ]
             ];
         }


### PR DESCRIPTION
Discover trying to build 1.20.1 , where dirname is commit ref, so with 0

     1) TheSeer\Autoload\Tests\PathComparatorTest::testComparatorYieldsCorrectCommonBase with data set "single" (array('/dev/shm/BUILD/Autoload-63813.../tests'), '/dev/shm/BUILD/Autoload-63813.../tests')
     Failed asserting that two strings are equal.
     --- Expected
     +++ Actual
     @@ @@
     -'/dev/shm/BUILD/Autoload-63813ec60cdfe966de8577e06aed40cd9a1720d8/tests'
     +'/dev/shm/BUILD/Autoload-63813ec6'
     
     /dev/shm/BUILD/Autoload-63813ec60cdfe966de8577e06aed40cd9a1720d8/tests/PathComparator.test.php:14
     
     2) TheSeer\Autoload\Tests\PathComparatorTest::testComparatorYieldsCorrectCommonBase with data set "two" (array('/dev/shm/BUILD/Autoload-63813.../tests', '/dev/shm/BUILD/Autoload-63813...1720d8'), '/dev/shm/BUILD/Autoload-63813...1720d8')
     Failed asserting that two strings are equal.
     --- Expected
     +++ Actual
     @@ @@
     -'/dev/shm/BUILD/Autoload-63813ec60cdfe966de8577e06aed40cd9a1720d8'
     +'/dev/shm/BUILD/Autoload-63813ec6'
     
     /dev/shm/BUILD/Autoload-63813ec60cdfe966de8577e06aed40cd9a1720d8/tests/PathComparator.test.php:14
     
     3) TheSeer\Autoload\Tests\PathComparatorTest::testComparatorYieldsCorrectCommonBase with data set "partns" (array('/dev/shm/BUILD/Autoload-63813...../src', '/dev/shm/BUILD/Autoload-63813...heseer'), '/dev/shm/BUILD/Autoload-63813...1720d8')
     Failed asserting that two strings are equal.
     --- Expected
     +++ Actual
     @@ @@
     -'/dev/shm/BUILD/Autoload-63813ec60cdfe966de8577e06aed40cd9a1720d8'
     +''
     
     /dev/shm/BUILD/Autoload-63813ec60cdfe966de8577e06aed40cd9a1720d8/tests/PathComparator.test.php:14
