### PR TITLE
don't use 'vendor' in test suite

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "zetacomponents/console-tools": "~1.7"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0",
+        "phpunit/phpunit": "~4.0|~5.0",
         "squizlabs/php_codesniffer": "~1.5"
     },
     "autoload": {

--- a/tests/PathComparator.test.php
+++ b/tests/PathComparator.test.php
@@ -26,7 +26,7 @@ namespace TheSeer\Autoload\Tests {
                     array(__DIR__, dirname(__DIR__)), dirname(__DIR__)
                 ],
                 'partns' => [
-                    array(__DIR__ . '/../src', __DIR__ . '/../vendor/theseer'), dirname(__DIR__)
+                    array(__DIR__ . '/../src', __DIR__ . '/../tests/_data'), dirname(__DIR__)
                 ],
                 'with0' => [
                     [$a=__DIR__.'/_data/parser/trait0.php'], $a


### PR DESCRIPTION
Minor fix for test suite, for people who don't use composer ;)

(really not a bug, just to make downstream life easier, no need to release)

Second one is about PHPUnit 5, as test suite pass with this new version.