### PR TITLE
fix test suite for PHP 5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
         "zetacomponents/console-tools": "~1.7"
     },
     "require-dev": {
+        "php": ">=5.3",
         "phpunit/phpunit": "~4.0|~5.0",
         "squizlabs/php_codesniffer": "~1.5"
     },

--- a/tests/PathComparatorTest.php
+++ b/tests/PathComparatorTest.php
@@ -15,29 +15,29 @@ namespace TheSeer\Autoload\Tests {
         }
 
         public function directoriesProvider() {
-            return [
-                'empty' => [
-                    [], '/'
-                ],
-                'single' => [
-                    [__DIR__], __DIR__
-                ],
-                'two' => [
-                    [__DIR__, dirname(__DIR__)], dirname(__DIR__)
-                ],
-                'parents' => [
-                    [__DIR__ . '/../src', __DIR__ . '/../tests/_data'], dirname(__DIR__)
-                ],
-                'with0' => [
-                    [$a=__DIR__.'/_data/parser/trait0.php'], $a
-                ],
-                'dirwithprefix' => [
-                    [__DIR__.'/_data/parser/trait0.php', __DIR__.'/_data/parser/trait1.php'], __DIR__.'/_data/parser'
-                ],
-                'dirwithoutprefix' => [
-                    [__DIR__, '/usr'], '/'
-                ]
-            ];
+            return array(
+                'empty' => array(
+                    array(), '/'
+                ),
+                'single' => array(
+                    array(__DIR__), __DIR__
+                ),
+                'two' => array(
+                    array(__DIR__, dirname(__DIR__)), dirname(__DIR__)
+                ),
+                'parents' => array(
+                    array(__DIR__ . '/../src', __DIR__ . '/../tests/_data'), dirname(__DIR__)
+                ),
+                'with0' => array(
+                    array($a=__DIR__.'/_data/parser/trait0.php'), $a
+                ),
+                'dirwithprefix' => array(
+                    array(__DIR__.'/_data/parser/trait0.php', __DIR__.'/_data/parser/trait1.php'), __DIR__.'/_data/parser'
+                ),
+                'dirwithoutprefix' => array(
+                    array(__DIR__, '/usr'), '/'
+                )
+            );
         }
     }
 


### PR DESCRIPTION
As README states "PHP 5.3+" I think it worth to be described in composer.json.

Other solution will be to raise minimal PHP required version to 5.4.

(doesn't worth a new release)