### PR TITLE
no cs/ci dir for statis tpl

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -314,6 +314,7 @@ namespace TheSeer\Autoload {
             if ($this->isPharMode()) {
                 if ($this->isStaticMode()) {
                     $tplFile = 'staticphar.php.tpl';
+                    $tplType = '.';
                 } else {
                     $tplFile = 'phar.php.tpl';
                 }


### PR DESCRIPTION
Discovered reading the code (I can't test this part).

But this seems logicial, according to :
```
$ find . -name \*tpl
./src/templates/cs/php52.php.tpl
./src/templates/cs/default.php.tpl
./src/templates/cs/phar.php.tpl
./src/templates/static.php.tpl
./src/templates/ci/php52.php.tpl
./src/templates/ci/default.php.tpl
./src/templates/ci/phar.php.tpl
./src/templates/staticphar.php.tpl
./tests/_data/templates/default.php.tpl
```

Please check this twice ;)