### PR TITLE
auto add suffix to (short) template name

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -301,6 +301,10 @@ namespace TheSeer\Autoload {
                     if (file_exists($alternative)) {
                         $template = $alternative;
                     }
+                    $alternative .= '.php.tpl';
+                    if (file_exists($alternative)) {
+                        $template = $alternative;
+                    }
                 }
                 return $template;
             }


### PR DESCRIPTION
This is only to be more user friendly.

so you can use `phpab --template=default  ...`

(the idea is to add more templates there, such as debian.php.tpl, fedora.php.tpl...)

FYI; work in progress to provide a simple autoloader (without using the Symfony, Zend or Composer one, to reduce dependencies), which will use phpab command for classmap : https://github.com/php-fedora/autoloader (template for phpab in the res directory)