### PR TITLE
Fix PHP 7.3 warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ php:
     - 5.6
     - 7.0
     - 7.1
+    - 7.2
+    - 7.3
     
 before_script:
     - composer install --prefer-dist --dev

--- a/src/CLI.php
+++ b/src/CLI.php
@@ -545,7 +545,7 @@ EOF;
             ));
 
             $warm = $input->registerOption( new \ezcConsoleOption(
-                'w','warm', \ezcConsoleInput::TYPE_NONE, NULL, FALSE,
+                'w', 'warm', \ezcConsoleInput::TYPE_NONE, NULL, FALSE,
                 'generate opcache warming file',
                 NULL,
                 array(),
@@ -556,7 +556,7 @@ EOF;
             ));
 
             $input->registerOption( new \ezcConsoleOption(
-                NULL,'reset', \ezcConsoleInput::TYPE_NONE, NULL, FALSE,
+                NULL, 'reset', \ezcConsoleInput::TYPE_NONE, NULL, FALSE,
                 'add reset call to generated opcache warming file',
                 NULL,
                 array(

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -166,32 +166,32 @@ namespace TheSeer\Autoload {
                     case T_COMMENT:
                     case T_DOC_COMMENT:
                     case T_WHITESPACE: {
-                        continue;
+                        break;
                     }
                     case T_STRING: {
                         $$mode .= $tok[1];
-                        continue;
+                        break;
                     }
                     case T_NS_SEPARATOR: {
                         $$mode .= '\\';
-                        continue;
+                        break;
                     }
                     case T_EXTENDS: {
                         $extendsFound = true;
                         $mode = 'extends';
-                        continue;
+                        break;
                     }
                     case T_IMPLEMENTS: {
                         $implementsFound = true;
                         $mode = 'implements';
-                        continue;
+                        break;
                     }
                     case ',': {
                         if ($mode == 'implements') {
                             $implementsList[] = $this->resolveDependencyName($implements);
                             $implements = '';
                         }
-                        continue;
+                        break;
                     }
                     default: {
                         throw new ParserException(sprintf(
@@ -233,11 +233,11 @@ namespace TheSeer\Autoload {
                     case T_NS_SEPARATOR:
                     case T_STRING: {
                         $$mode .= $tok[1];
-                        continue;
+                        break;
                     }
                     case T_EXTENDS: {
                         $mode = 'extends';
-                        continue;
+                        break;
                     }
                     case ',': {
                         if ($mode == 'extends') {
@@ -389,18 +389,18 @@ namespace TheSeer\Autoload {
                                 break;
                             }
                         }
-                        continue;
+                        break;
                     }
                     case ';':
                     case ',': {
                         $this->dependencies[$this->inUnit][] = $this->resolveDependencyName($use);
                         $use = '';
-                        continue;
+                        break;
                     }
                     case T_NS_SEPARATOR:
                     case T_STRING: {
                         $use .= $current[1];
-                        continue;
+                        break;
                     }
                 }
             }
@@ -421,11 +421,11 @@ namespace TheSeer\Autoload {
                     case T_CONST:
                     case T_FUNCTION: {
                         $ignore = true;
-                        continue;
+                        break;
                     }
                     case '{': {
                         $group = $use;
-                        continue;
+                        break;
                     }
                     case ';':
                     case ',': {
@@ -447,16 +447,16 @@ namespace TheSeer\Autoload {
                         $use = $group;
                         $mode = 'use';
                         $ignore = false;
-                        continue;
+                        break;
                     }
                     case T_NS_SEPARATOR:
                     case T_STRING: {
                         $$mode .= $current[1];
-                        continue;
+                        break;
                     }
                     case T_AS: {
                         $mode = 'alias';
-                        continue;
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
From Fedora QA, see https://apps.fedoraproject.org/koschei/package/php-theseer-autoload?collection=f30


=> PHP Warning:  Uncaught "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"?