### PR TITLE
Throw an exception if the template file cannot be read

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -61,8 +61,14 @@ namespace TheSeer\Autoload {
             if ($this->config->isCacheEnabled()) {
                 $this->factory->getCache()->persist($this->config->getCacheFile());
             }
+
+            $template = @file_get_contents($this->config->getTemplate());
+            if ($template === false) {
+                throw new ApplicationException("Failed to read the template file.");
+            }
+
             $builder = $this->factory->getRenderer($result);
-            $code = $builder->render(file_get_contents($this->config->getTemplate()));
+            $code = $builder->render($template);
             if ($this->config->isLintMode()) {
                 return $this->runLint($code);
             }


### PR DESCRIPTION
Currently, if the template cannot be read, the code will produce a PHP Warning on `stderr` and then continue on its merry way.

This changeset makes the code throw an exception if the template does not exist, alerting the user to the issue.