### PR TITLE
fix for xdebug v3

### DIFF
--- a/src/CLI.php
+++ b/src/CLI.php
@@ -591,7 +591,9 @@ EOF;
                 ini_set('xdebug.scream', 0);
                 ini_set('xdebug.max_nesting_level', 8192);
                 ini_set('xdebug.show_exception_trace', 0);
-                xdebug_disable();
+                if (function_exists('xdebug_disable')) { // Xdebug v2
+                    xdebug_disable();
+                }
             }
 
         }


### PR DESCRIPTION
This function was dropped in v3

> xdebug_disable()
> 
>     Has been removed.
> 
>     To prevent Xdebug from showing stack traces, do not configure Xdebug's
>     develop mode in xdebug.mode, or turn off PHP's html_errors INI setting.
