### PR TITLE
GH Actions: set error reporting to E_ALL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          ini-values: error_reporting=-1, display_errors=On, log_errors_max_len=0
           coverage: none
           tools: phive
 


### PR DESCRIPTION
_Sorry, forgot to add this in the previous PR (#101)._

Turns out the default setting for `error_reporting` used by the SetupPHP action is `error_reporting=E_ALL & ~E_DEPRECATED & ~E_STRICT` and `display_errors` is set to `Off`.

For the purposes of CI, I'd recommend running with `E_ALL` and `display_errors=On` to ensure **all** PHP notices are shown.

Note: this now makes the PHP 8.1 build fail on deprecation notices. By the looks of it, these should all be reported upstream in the various dependencies.