### PR TITLE
Return exit code from CLI::run(), rather than exiting

### DIFF
--- a/composer/bin/phpab
+++ b/composer/bin/phpab
@@ -59,5 +59,5 @@ foreach ($files as $file) {
 require __DIR__ . '/../../src/autoload.php';
 
 $factory = new \TheSeer\Autoload\Factory();
-$factory->getCLI()->run($_SERVER);
-exit(0);
+$rc = $factory->getCLI()->run($_SERVER);
+exit($rc);

--- a/phpab.php
+++ b/phpab.php
@@ -51,5 +51,5 @@ if (!ini_get('date.timezone')) {
 require __DIR__ . '/src/autoload.php';
 
 $factory = new \TheSeer\Autoload\Factory();
-$factory->getCLI()->run($_SERVER);
-exit(0);
+$rc = $factory->getCLI()->run($_SERVER);
+exit($rc);

--- a/src/CLI.php
+++ b/src/CLI.php
@@ -71,7 +71,7 @@ namespace TheSeer\Autoload {
         /**
          * Main executor method
          *
-         * @return void
+         * @return int exit code
          */
         public function run(array $env) {
 
@@ -99,19 +99,19 @@ namespace TheSeer\Autoload {
                     $this->showVersion();
                 }
                 $rc = $this->factory->getApplication()->run();
-                exit($rc);
+                return $rc;
 
             } catch (CLIEnvironmentException $e) {
                 $this->showVersion();
                 fwrite(STDERR, 'Sorry, but your PHP environment is currently not able to run phpab due to');
                 fwrite(STDERR, "\nthe following issue(s):\n\n" . $e->getMessage() . "\n\n");
                 fwrite(STDERR, "Please adjust your PHP configuration and try again.\n\n");
-                exit(CLI::RC_EXEC_ERROR);
+                return CLI::RC_EXEC_ERROR;
             } catch (\ezcConsoleException $e) {
                 $this->showVersion();
                 echo $e->getMessage() . "\n\n";
                 $this->showUsage();
-                exit(CLI::RC_PARAM_ERROR);
+                return CLI::RC_PARAM_ERROR;
             } catch (CollectorException $e) {
                 switch($e->getCode()) {
                     case CollectorException::InFileRedeclarationFound:
@@ -126,11 +126,11 @@ namespace TheSeer\Autoload {
                 }
                 $this->showVersion();
                 fwrite(STDERR, $message . "\n\n");
-                exit(CLI::RC_EXEC_ERROR);
+                return CLI::RC_EXEC_ERROR;
             } catch (\Exception $e) {
                 $this->showVersion();
                 fwrite(STDERR, "\nError while processing request:\n - " . $e->getMessage()."\n");
-                exit(CLI::RC_EXEC_ERROR);
+                return CLI::RC_EXEC_ERROR;
             }
 
         }


### PR DESCRIPTION
When using `CLI` from another script, exiting straight from `run()` method does not allow custom error handling.

Returning the exit code to the invoking script and exiting there allows custom error handling in an external script, while remaining completely backwards-compatible.