### PR TITLE
Support passing configuration arguments to CLI::run()

### DIFF
--- a/composer/bin/phpab
+++ b/composer/bin/phpab
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 /**
- * Copyright (c) 2009-2016 Arne Blankerts <arne@blankerts.de>
+ * Copyright (c) 2009-2023 Arne Blankerts <arne@blankerts.de>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -59,5 +59,5 @@ foreach ($files as $file) {
 require __DIR__ . '/../../src/autoload.php';
 
 $factory = new \TheSeer\Autoload\Factory();
-$rc = $factory->getCLI()->run($_SERVER);
+$rc = $factory->getCLI()->run();
 exit($rc);

--- a/phpab.php
+++ b/phpab.php
@@ -51,5 +51,5 @@ if (!ini_get('date.timezone')) {
 require __DIR__ . '/src/autoload.php';
 
 $factory = new \TheSeer\Autoload\Factory();
-$rc = $factory->getCLI()->run($_SERVER);
+$rc = $factory->getCLI()->run();
 exit($rc);


### PR DESCRIPTION
@theseer This is a request for comment!

I've noticed you have added the `$env` parameter for the `run()` method.

It is not clear to me, why you would pass a super-global (i.e. `$_SERVER`) as a parameter, unless the parameter could also be different. Now, in the current code, there is no other use. Has that been to allow external scripts to provide the environment?

Similar to the PR regarding exit codes, it would be awesome to have the possibility to pass the options as a parameter to `run()`, rather than have to mess with the `$_SERVER['argv']` variable. That's why I had added the `$options` a while ago (unfortunately I forgot to create a PR).

I'm happy to the flip the `$options` and `$env` parameters. However, unless there is a known use-case, I find that the `$env` parameter us probably less likely to be overwritten, given that it's only used to evaluate the home directory.

What is your view on this? Would you see my PR as useful, as it is (but officially breaking backwards-compatibility) or shall I flip the parameters? Or do you have yet another idea?

PS: also speaking German, if that would be an issue at all! :-)