### PR TITLE
Add opensssl extension as a required dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "A tool and library to generate autoload code.",
     "require": {
         "php": ">=5.3",
+        "ext-openssl": "*",
         "theseer/directoryscanner": "^1.3.3",
         "zetacomponents/console-tools": "^1.7"
     },


### PR DESCRIPTION
Added a dependency in `composer.json` ...

https://github.com/theseer/Autoload/blob/e1b5f8c4554c12652c7ec02440f94e1bf7150148/composer.json#L6

... due to the usage of `openssl_pkey_export` and `openssl_pkey_get_details` in https://github.com/theseer/Autoload/blob/9235b0766d06a209826e46f9657429ac9fd2eef4/src/PharBuilder.php#L98-L100